### PR TITLE
Fix default login when using reverse proxy

### DIFF
--- a/custom_components/auth_header/__init__.py
+++ b/custom_components/auth_header/__init__.py
@@ -117,7 +117,8 @@ class RequestLoginFlowIndexView(LoginFlowIndexView):
                 handler,  # type: ignore[arg-type]
                 context={
                     "request": request,
-                    "ip_address": ip_address(actual_ip),  # type: ignore[arg-type]
+                    "ip_address": ip_address(request.remote),  # type: ignore[arg-type]
+                    "conn_ip_address": ip_address(actual_ip),  # type: ignore[arg-type]
                     "credential_only": data.get("type") == "link_user",
                     "redirect_uri": redirect_uri,
                 },

--- a/custom_components/auth_header/headers.py
+++ b/custom_components/auth_header/headers.py
@@ -53,7 +53,7 @@ class HeaderAuthProvider(AuthProvider):
                 self,
                 None,
                 [],
-                cast(IPAddress, context.get("ip_address")),
+                cast(IPAddress, context.get("conn_ip_address")),
             )
         remote_user = request.headers[header_name]
         # Translate username to id
@@ -65,7 +65,7 @@ class HeaderAuthProvider(AuthProvider):
             self,
             remote_user,
             available_users,
-            cast(IPAddress, context.get("ip_address")),
+            cast(IPAddress, context.get("conn_ip_address")),
         )
 
     async def async_user_meta_for_credentials(


### PR DESCRIPTION
Some non-overridden code upstream relied on the ip_address value in the auth context being the resolved value from the X-Forwarded-For header if enabled. This would cause regular login to fail with the plugin enabled and using a reverse proxy.

This PR adds a new field to the context, `conn_ip_address`, which is used for checking the source IP of the connection. `ip_address` is passed through to hass unchanged.

Fixes #105, tested on my instance.