### PR TITLE
make remote_user case-insensitive

### DIFF
--- a/custom_components/auth_header/headers.py
+++ b/custom_components/auth_header/headers.py
@@ -55,7 +55,7 @@ class HeaderAuthProvider(AuthProvider):
                 [],
                 cast(IPAddress, context.get("conn_ip_address")),
             )
-        remote_user = request.headers[header_name]
+        remote_user = request.headers[header_name].casefold()
         # Translate username to id
         users = await self.store.async_get_users()
         available_users = [


### PR DESCRIPTION
Home Assistant implemented a change in https://github.com/home-assistant/core/pull/20558 to make usernames case-insensitive. So usernames in Authentik like mine (F1rby) were not being matched to the username in Home Assistant (f1rby).

There is no easy way in Home Assistant to force a username to be case sensitive, or to edit an existing username. When you request a username, it is automatically stripped to lower-case using `casefold()` (see above home assistant PR.) Home Assistant does implement a migration check to see if their case-insensitive username conflicts with any existing usernames. If it does, the auth provider enables "legacy mode" and throws an error. I belive this is the only way a case sensitive name will be added to the auth file. I don't try and handle that case in this PR. I simply modify the username pulled from the auth header using the same `casefold()` method before it is matched.

I've tested this on my own Home Assistant instance and it works, but I'm no Python programmer. I am seeing an uptick in errors from the log in the aiohttp.server module. Specifically `ERROR (MainThread) [aiohttp.server] Error handling request` and I'm not sure why. May be unrelated.