### PR TITLE
Store the token in localStorage after login

### DIFF
--- a/custom_components/auth_header/__init__.py
+++ b/custom_components/auth_header/__init__.py
@@ -1,5 +1,6 @@
 import logging
 from http import HTTPStatus
+import os.path
 from ipaddress import ip_address
 from typing import Any, OrderedDict, TYPE_CHECKING
 
@@ -63,6 +64,13 @@ async def async_setup(hass: HomeAssistant, config):
             hass.auth.login_flow, store_result, config[DOMAIN]["debug"]
         )
     )
+
+    # Load script to store tokens in local storage, else we'll re-auth on every browser refresh.
+    hass.http.register_static_path(
+        "/auth_header/store-token.js",
+        os.path.join(os.path.dirname(__file__), 'store-token.js'),
+    )
+    hass.components.frontend.add_extra_js_url(hass, '/auth_header/store-token.js')
 
     # Inject Auth-Header provider.
     providers = OrderedDict()

--- a/custom_components/auth_header/store-token.js
+++ b/custom_components/auth_header/store-token.js
@@ -1,0 +1,15 @@
+(() => {
+	// Store the login token in localStorage as soon as they are available. This is normally done (depending on whether the user enabled the "Keep me logged in" option) in https://github.com/home-assistant/frontend/blob/6653a8f63426755d6a58bce0ef3d55d83d8ec99c/src/common/auth/token_storage.ts
+	let attemptsRemaining = 10;
+	const interval = setInterval(() => {
+		attemptsRemaining -= 1;
+		if (window.__tokenCache.tokens) {
+			localStorage.setItem("hassTokens", JSON.stringify(window.__tokenCache.tokens))
+			window.__tokenCache.writeEnabled = true;
+			attemptsRemaining = 0;
+		}
+		if (attemptsRemaining <= 0) {
+			clearInterval(interval);
+		}
+	}, 1000);
+})();


### PR DESCRIPTION
Without this every page (re)load creates a new token. The normal login flow does this if the user checks the "Keep me logged in" option, but we bypass this entirely.

Fixes #151.